### PR TITLE
Push comment replies with inReplyTo, not inReplyToNum

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -31,7 +31,7 @@ class API {
 	/**
 	 * Publish a post.
 	 *
-	 * @param array $item Item payload (e.g. description, title, inReplyToNum).
+	 * @param array $item Item payload (e.g. description, title, inReplyTo).
 	 * @return array|\WP_Error
 	 */
 	public function new_post( array $item ) {

--- a/includes/class-syndication.php
+++ b/includes/class-syndication.php
@@ -175,8 +175,11 @@ class Syndication {
 
 		$result = ( new API() )->new_post(
 			array(
-				'description'  => \wpautop( $comment->comment_content ),
-				'inReplyToNum' => $parent_id,
+				'description' => \wpautop( $comment->comment_content ),
+				// The server stores the parent in its "inReplyTo" field; "inReplyToNum"
+				// is only the name a reply carries when read back, and older self-hosted
+				// instances do not accept it on write. Always post as "inReplyTo".
+				'inReplyTo'   => $parent_id,
 			)
 		);
 		if ( \is_wp_error( $result ) ) {

--- a/tests/phpunit/tests/class-test-syndication.php
+++ b/tests/phpunit/tests/class-test-syndication.php
@@ -134,7 +134,7 @@ class Test_Syndication extends TestCase {
 	}
 
 	/**
-	 * A comment on a synced post is pushed as a reply with inReplyToNum.
+	 * A comment on a synced post is pushed as a reply with inReplyTo.
 	 */
 	public function test_comment_on_synced_post_pushes_reply() {
 		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
@@ -150,7 +150,7 @@ class Test_Syndication extends TestCase {
 
 		$this->assertCount( 1, $this->newposts );
 		$payload = $this->payload( $this->newposts[0] );
-		$this->assertSame( 100, (int) $payload['inReplyToNum'] );
+		$this->assertSame( 100, (int) $payload['inReplyTo'] );
 	}
 
 	/**


### PR DESCRIPTION
Comments on a synced post were pushed to rss.chat with an `inReplyToNum` field, and they landed as standalone posts instead of replies. Reported in #1.

The reason: `inReplyToNum` is only the name the server gives a reply when you *read* it back. On write, the server stores the parent in a field called `inReplyTo`. It only started accepting `inReplyToNum` as an alias on write on 2026-07-27, so self-hosted instances that predate that just drop it and the reply loses its parent.

You can see it on Andy's instance: [id=22](https://rsschat.andysylvester.com/?id=22) and [id=23](https://rsschat.andysylvester.com/?id=23) are plugin-pushed comments with no `inReplyToNum`, while [id=21](https://rsschat.andysylvester.com/?id=21), typed in the rss.chat client, threads fine.

So this pushes `inReplyTo` instead, which every instance understands, old and new. The backfeed side keeps reading `inReplyToNum`, that is still the right name on read.

Tests pass in wp-env. This does not touch #1's second question (own replies not coming back), that one is next.