### PR TITLE
Let own rss.chat replies come back into WordPress

### DIFF
--- a/includes/class-backfeed.php
+++ b/includes/class-backfeed.php
@@ -97,26 +97,23 @@ class Backfeed {
 			)
 		);
 
-		$own = Plugin::get_account()['screenname'];
-
 		foreach ( $posts as $post_id ) {
 			$rss_id = (int) \get_post_meta( $post_id, Plugin::META_ID, true );
 			if ( $rss_id <= 0 ) {
 				continue;
 			}
-			$this->import_replies( $post_id, $rss_id, $own );
+			$this->import_replies( $post_id, $rss_id );
 		}
 	}
 
 	/**
 	 * Import the replies of one synced post.
 	 *
-	 * @param int    $post_id Local post id.
-	 * @param int    $rss_id  rss.chat id of the post.
-	 * @param string $own     Our own screen name, whose replies we skip.
+	 * @param int $post_id Local post id.
+	 * @param int $rss_id  rss.chat id of the post.
 	 * @return void
 	 */
-	private function import_replies( $post_id, $rss_id, $own ) {
+	private function import_replies( $post_id, $rss_id ) {
 		$items = ( new API() )->get_item_and_replies( $rss_id );
 		if ( \is_wp_error( $items ) || ! \is_array( $items ) ) {
 			return;
@@ -130,10 +127,11 @@ class Backfeed {
 			if ( isset( $item['id'] ) && (int) $item['id'] === $rss_id ) {
 				continue;
 			}
-			// Skip our own replies; they originated in WordPress.
-			if ( '' !== $own && isset( $item['screenname'] ) && $item['screenname'] === $own ) {
-				continue;
-			}
+			// The guid dedup below is the only loop guard we need: a reply that
+			// WordPress pushed already carries its guid on a comment, so it is
+			// skipped here. Replies the owner wrote directly on rss.chat, even
+			// under the same account, have a guid we have not seen, so they come
+			// home like anyone else's.
 			if ( $this->already_imported( $item['guid'] ) ) {
 				continue;
 			}

--- a/tests/phpunit/tests/class-test-backfeed.php
+++ b/tests/phpunit/tests/class-test-backfeed.php
@@ -71,8 +71,8 @@ class Test_Backfeed extends TestCase {
 	}
 
 	/**
-	 * The synthetic reply feed: the post, one reply, our own reply (skipped),
-	 * and a nested reply to the first reply.
+	 * The synthetic reply feed: the post, one reply, our own reply (which now
+	 * comes home too, deduped only by guid), and a nested reply to the first.
 	 *
 	 * @return array
 	 */
@@ -133,24 +133,54 @@ class Test_Backfeed extends TestCase {
 	}
 
 	/**
-	 * Replies become comments; the post itself and our own reply are skipped.
+	 * Replies become comments, including the owner's own reply written on
+	 * rss.chat; only the post itself is skipped.
 	 */
-	public function test_imports_others_replies_only() {
+	public function test_imports_all_replies_including_own() {
 		$post_id = $this->synced_post();
 
 		( new Backfeed() )->run();
 
 		$comments = $this->comments_on( $post_id );
-		$this->assertCount( 2, $comments, 'only Alice and Bob replies should import' );
+		$this->assertCount( 3, $comments, 'Alice, Bob and the owner reply should import' );
 
 		$guids = array();
 		foreach ( $comments as $comment ) {
 			$guids[] = \get_comment_meta( $comment->comment_ID, Plugin::META_GUID, true );
 		}
 		$this->assertContains( 'https://rss.chat/?id=201', $guids );
+		$this->assertContains( 'https://rss.chat/?id=202', $guids, 'own reply comes home too' );
 		$this->assertContains( 'https://rss.chat/?id=203', $guids );
-		$this->assertNotContains( 'https://rss.chat/?id=202', $guids, 'own reply skipped' );
 		$this->assertNotContains( 'https://rss.chat/?id=200', $guids, 'the post itself skipped' );
+	}
+
+	/**
+	 * A reply WordPress itself pushed is not re-imported: it already carries its
+	 * guid on a comment, so guid dedup catches it even under the owner account.
+	 */
+	public function test_own_pushed_reply_not_reimported() {
+		$post_id = $this->synced_post();
+
+		// Simulate the comment WordPress pushed for reply 202: it stored the guid.
+		$pushed = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'my own reply',
+				'comment_approved' => 1,
+			)
+		);
+		\update_comment_meta( $pushed, Plugin::META_GUID, 'https://rss.chat/?id=202' );
+
+		( new Backfeed() )->run();
+
+		$with_guid = \get_comments(
+			array(
+				'post_id'    => $post_id,
+				'meta_key'   => Plugin::META_GUID, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => 'https://rss.chat/?id=202', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+		$this->assertCount( 1, $with_guid, 'reply 202 must not be imported a second time' );
 	}
 
 	/**
@@ -203,7 +233,7 @@ class Test_Backfeed extends TestCase {
 		( new Backfeed() )->run();
 		( new Backfeed() )->run();
 
-		$this->assertCount( 2, $this->comments_on( $post_id ) );
+		$this->assertCount( 3, $this->comments_on( $post_id ) );
 	}
 
 	/**


### PR DESCRIPTION
Reported in #1: a reply you write on rss.chat under the same account you connected to WordPress never comes back as a comment. A reply from a second account does. So it looked like replies had to be from someone else.

The reason was a skip in backfeed: it dropped any reply whose `screenname` matched the connected account, on the assumption that our own replies always originated in WordPress. That is too broad. It also drops the ones you typed directly on rss.chat.

We do not need that skip. The guid dedup right below it is enough: a reply WordPress pushed already carries its guid on a comment, so it is skipped there. A reply you wrote on rss.chat has a guid we have not seen, so it comes home like anyone else's, and the loop guard still holds (imported comments keep the `Backfeed::$importing` guard and store their guid, so they are never pushed back out).

So this removes the screenname skip and leans on guid dedup alone. Added a test that a reply WordPress itself pushed is not re-imported, and updated the ones that assumed own replies were dropped.

Tests pass in wp-env (18, 40 assertions).